### PR TITLE
Adds API key config for Bing and DarkSky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log
 /priv/static/
 
 .elixir_ls
+.env

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -4,6 +4,9 @@
 # remember to add this file to your .gitignore.
 use Mix.Config
 
+bing_api_key = System.get_env("BING_API_KEY")
+dark_sky__api_key = System.get_env("DARK_SKY_API_KEY")
+
 database_url =
   System.get_env("DATABASE_URL") ||
     raise """


### PR DESCRIPTION
Co-authored-by: TheCraftedGem <thecraftedgem@tuta.io>

Adds API key config for 
- DarkSky Weather API
- Bing Geocoding API

Closes #7 

Note to add to README that you must:
1. Create `.env` file in the root of your project with this syntax for your keys
```
export BING_API_KEY="insert-key-here"
export DARK_SKY_API_KEY="insert-key-here"
```

2. In your terminal run `source .env`

Reference:
https://medium.com/@kkomaz/phoenix-setting-up-env-variables-6557eb1370ee