### PR TITLE
Adds new /autocomplete route with API call to Bing

### DIFF
--- a/lib/live_view_weather_web/controllers/page_controller.ex
+++ b/lib/live_view_weather_web/controllers/page_controller.ex
@@ -9,4 +9,8 @@ defmodule LiveViewWeatherWeb.PageController do
   def test(conn, _params) do
     LiveView.Controller.live_render(conn, LiveViewWeatherWeb.GithubDeployView, session: %{})
   end
+
+  def autocomplete(conn, _params) do
+    LiveView.Controller.live_render(conn, LiveViewWeatherWeb.Autocomplete, session: %{})
+  end
 end

--- a/lib/live_view_weather_web/live/autocomplete.ex
+++ b/lib/live_view_weather_web/live/autocomplete.ex
@@ -1,0 +1,65 @@
+defmodule AutocompleteResult do
+  defstruct [:name, :coordinates]
+end
+
+defmodule LiveViewWeatherWeb.Autocomplete do
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    LiveViewWeatherWeb.PageView.render("autocomplete.html", assigns)
+  end
+
+  def mount(_session, socket) do
+    {:ok, assign(socket, q: nil, recommendations: nil)}
+  end
+
+  def handle_event("autocomplete", value, socket) do
+    q = String.trim(value["q"])
+
+    {:noreply, assign(socket, recommendations: fetch_autocomplete(q))}
+  end
+
+  defp fetch_autocomplete(q) do
+    case bing_cities(q) do
+      {:ok, cities} -> Enum.map(cities, fn city -> city.name end)
+      {:error, _message} -> []
+    end
+  end
+
+  def bing_cities(q) do
+    token = System.get_env("BING_API_KEY")
+    url = URI.encode("http://dev.virtualearth.net/REST/v1/Locations?query=#{q}&key=#{token}")
+
+    # Note to cache results from API call here
+    with {:ok, resp} <- HTTPoison.get(url),
+      resp <- IO.inspect(resp, label: "RESP"),
+      {:ok, decoded} <- Jason.decode(resp.body),
+      {:ok, cities} <- extract_resource_sets(decoded) do
+      {:ok, cities}
+    else
+      {:error, %HTTPoison.Error{reason: reason}} -> {:error, reason}
+      {:error, %Jason.DecodeError{data: data}} -> {:error, data}
+      {:error, :no_results} -> {:error, "no_results"}
+      message -> IO.inspect(message, label: "messsage")
+    end
+  end
+
+  def extract_resource_sets(%{"resourceSets" => resource_sets}) do
+    extracted_data = Enum.flat_map(resource_sets, &extract_resources_from_resource_set/1)
+    case extracted_data do
+      [] -> {:error, :no_results}
+      _ -> {:ok, extracted_data}
+    end
+  end
+  def extract_resource_sets(_params), do: []
+
+  def extract_resources_from_resource_set(%{"resources" => resources}) do
+    Enum.map(resources, &get_autocomplete_result/1)
+  end
+  def extract_resources_from_resource_set(_params), do: []
+
+  def get_autocomplete_result(%{"name" => name, "point" => %{"coordinates" => coordinates}}) do
+    %AutocompleteResult{name: name, coordinates: coordinates}
+  end
+  def get_autocomplete_result(_params), do: []
+end

--- a/lib/live_view_weather_web/router.ex
+++ b/lib/live_view_weather_web/router.ex
@@ -19,6 +19,7 @@ defmodule LiveViewWeatherWeb.Router do
 
     get "/", PageController, :index
     get "/test", PageController, :test
+    get "/autocomplete", PageController, :autocomplete
   end
 
   # Other scopes may use custom stacks.

--- a/lib/live_view_weather_web/templates/page/autocomplete.html.leex
+++ b/lib/live_view_weather_web/templates/page/autocomplete.html.leex
@@ -1,0 +1,7 @@
+<form phx-change="autocomplete">
+  <div style="width:300px;">
+    <input value="<%= @q %>" id="myInput" type="text" name="q" placeholder="Enter a city">
+    <p><%= @recommendations %></p>
+  </div>
+  <input type="submit">
+</form>


### PR DESCRIPTION
Co-authored-by: TheCraftedGem <thecraftedgem@tuta.io>

Adds new endpoint `/autocomplete` for testing how an autocomplete of a search form can be implemented using Bing's geocoding API

References:
https://docs.microsoft.com/en-us/bingmaps/rest-services/locations/find-a-location-by-query